### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
Adds the missing GitHub Skills extracurricular activity that was announced by the principal.

## Changes
- Added "GitHub Skills" to the activities dictionary in `app.py`
- Configured with appropriate schedule, capacity, and description
- Activity is now available for student registration

## Details
- **Schedule**: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- **Max Participants**: 25 students
- **Description**: Includes reference to GitHub Certifications program

## Resolves
Fixes #6 - Students can now sign up for the time-sensitive GitHub Skills activity before registration closes this week.

---
> **Note**: This PR addresses the urgent request from issue #6 where students could not find the GitHub Skills activity for registration.